### PR TITLE
- Added tv_usec to temp directory names to make it more unique.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -420,9 +420,9 @@ int generate_random_tmpdir(char *buffer, int bufsize, int n)
     abstime=tv.tv_sec;
         localtime_r(&abstime, &tbreak);
     
-    snprintf(buffer, bufsize, "/tmp/fsa/%.4d%.2d%.2d-%.2d%.2d%.2d-%.2d",
+    snprintf(buffer, bufsize, "/tmp/fsa/%.4d%.2d%.2d-%.2d%.2d%.2d-%.8x-%.2d",
         tbreak.tm_year+1900, tbreak.tm_mon+1, tbreak.tm_mday,
-         tbreak.tm_hour, tbreak.tm_min, tbreak.tm_sec, n);
+         tbreak.tm_hour, tbreak.tm_min, tbreak.tm_sec, (u32)tv.tv_usec, n);
     return 0;
 }
 


### PR DESCRIPTION
This is an issue I've encountered in my own projects using multiple drives running fsarchiver in parallel.

If more than one fsarchiver session is started in parallel, there's a chance of temp directory collision if they try to create a tmp directory at the same second.  
Adding usec to the directory name fixes this issue.