### PR TITLE
Fix compilation with the musl c library

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -29,10 +29,13 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <execinfo.h>
 #include <wordexp.h>
 #include <fnmatch.h>
 #include <time.h>
+
+#ifdef HAVE_EXECINFO_H
+#include <execinfo.h>
+#endif
 
 #include "fsarchiver.h"
 #include "syncthread.h"
@@ -549,6 +552,7 @@ u64 stats_errcount(cstats stats)
 
 int format_stacktrace(char *buffer, int bufsize)
 {
+#ifdef HAVE_EXECINFO_H
     const int stack_depth=20;
     void *temp[stack_depth];
     char **strings;
@@ -565,6 +569,7 @@ int format_stacktrace(char *buffer, int bufsize)
             strlcatf(buffer, bufsize, "%s\n", strings[i]);
         free(strings);
     }
+#endif
     
     return 0;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -32,6 +32,7 @@
 #include <wordexp.h>
 #include <fnmatch.h>
 #include <time.h>
+#include <limits.h>
 
 #ifdef HAVE_EXECINFO_H
 #include <execinfo.h>

--- a/src/devinfo.c
+++ b/src/devinfo.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <blkid.h>
+#include <limits.h>
 
 #include "fsarchiver.h"
 #include "devinfo.h"

--- a/src/fs_xfs.h
+++ b/src/fs_xfs.h
@@ -55,34 +55,34 @@ int xfs_umount(char *partition, char *mntbuf);
 int xfs_test(char *devname);
 int xfs_check_compatibility(u64 compat, u64 ro_compat, u64 incompat, u64 log_incompat);
 
-typedef __uint32_t      xfs_agblock_t;  /* blockno in alloc. group */
-typedef __uint32_t      xfs_extlen_t;   /* extent length in blocks */
-typedef __uint32_t      xfs_agnumber_t; /* allocation group number */
-typedef __int32_t       xfs_extnum_t;   /* # of extents in a file */
-typedef __int16_t       xfs_aextnum_t;  /* # extents in an attribute fork */
-typedef __int64_t       xfs_fsize_t;    /* bytes in a file */
-typedef __uint64_t      xfs_ufsize_t;   /* unsigned bytes in a file */
+typedef uint32_t      xfs_agblock_t;  /* blockno in alloc. group */
+typedef uint32_t      xfs_extlen_t;   /* extent length in blocks */
+typedef uint32_t      xfs_agnumber_t; /* allocation group number */
+typedef int32_t       xfs_extnum_t;   /* # of extents in a file */
+typedef int16_t       xfs_aextnum_t;  /* # extents in an attribute fork */
+typedef int64_t       xfs_fsize_t;    /* bytes in a file */
+typedef uint64_t      xfs_ufsize_t;   /* unsigned bytes in a file */
 
-typedef __int32_t       xfs_suminfo_t;  /* type of bitmap summary info */
-typedef __int32_t       xfs_rtword_t;   /* word type for bitmap manipulations */
+typedef int32_t       xfs_suminfo_t;  /* type of bitmap summary info */
+typedef int32_t       xfs_rtword_t;   /* word type for bitmap manipulations */
  
-typedef __int64_t       xfs_lsn_t;      /* log sequence number */
-typedef __int32_t       xfs_tid_t;      /* transaction identifier */
+typedef int64_t       xfs_lsn_t;      /* log sequence number */
+typedef int32_t       xfs_tid_t;      /* transaction identifier */
 
-typedef __uint32_t      xfs_dablk_t;    /* dir/attr block number (in file) */
-typedef __uint32_t      xfs_dahash_t;   /* dir/attr hash value */
+typedef uint32_t      xfs_dablk_t;    /* dir/attr block number (in file) */
+typedef uint32_t      xfs_dahash_t;   /* dir/attr hash value */
 
-typedef __uint16_t      xfs_prid_t;     /* prid_t truncated to 16bits in XFS */
+typedef uint16_t      xfs_prid_t;     /* prid_t truncated to 16bits in XFS */
 
 /*
  * These types are 64 bits on disk but are either 32 or 64 bits in memory.
  * Disk based types:
  */
-typedef __uint64_t      xfs_fsblock_t;  /* blockno in filesystem (agno|agbno) */
-typedef __uint64_t      xfs_rfsblock_t; /* blockno in filesystem (raw) */
-typedef __uint64_t      xfs_rtblock_t;  /* extent (block) in realtime area */
-typedef __uint64_t      xfs_dfiloff_t;  /* block number in a file */
-typedef __uint64_t      xfs_dfilblks_t; /* number of blocks in a file */
+typedef uint64_t      xfs_fsblock_t;  /* blockno in filesystem (agno|agbno) */
+typedef uint64_t      xfs_rfsblock_t; /* blockno in filesystem (raw) */
+typedef uint64_t      xfs_rtblock_t;  /* extent (block) in realtime area */
+typedef uint64_t      xfs_dfiloff_t;  /* block number in a file */
+typedef uint64_t      xfs_dfilblks_t; /* number of blocks in a file */
 
 typedef __s64           xfs_off_t;      /* <file offset> type */
 typedef __u64           xfs_ino_t;      /* <inode> type */
@@ -97,8 +97,8 @@ typedef __u32           xfs_nlink_t;
  */
 struct xfs_sb
 {
-        __uint32_t      sb_magicnum;    /* magic number == XFS_SB_MAGIC */
-        __uint32_t      sb_blocksize;   /* logical block size, bytes */
+        uint32_t      sb_magicnum;    /* magic number == XFS_SB_MAGIC */
+        uint32_t      sb_blocksize;   /* logical block size, bytes */
         xfs_rfsblock_t  sb_dblocks;     /* number of data blocks */
         xfs_rfsblock_t  sb_rblocks;     /* number of realtime blocks */
         xfs_rtblock_t   sb_rextents;    /* number of realtime extents */
@@ -112,45 +112,45 @@ struct xfs_sb
         xfs_agnumber_t  sb_agcount;     /* number of allocation groups */
         xfs_extlen_t    sb_rbmblocks;   /* number of rt bitmap blocks */
         xfs_extlen_t    sb_logblocks;   /* number of log blocks */
-        __uint16_t      sb_versionnum;  /* header version == XFS_SB_VERSION */
-        __uint16_t      sb_sectsize;    /* volume sector size, bytes */
-        __uint16_t      sb_inodesize;   /* inode size, bytes */
-        __uint16_t      sb_inopblock;   /* inodes per block */
+        uint16_t      sb_versionnum;  /* header version == XFS_SB_VERSION */
+        uint16_t      sb_sectsize;    /* volume sector size, bytes */
+        uint16_t      sb_inodesize;   /* inode size, bytes */
+        uint16_t      sb_inopblock;   /* inodes per block */
         char            sb_fname[12];   /* file system name */
-        __uint8_t       sb_blocklog;    /* log2 of sb_blocksize */
-        __uint8_t       sb_sectlog;     /* log2 of sb_sectsize */
-        __uint8_t       sb_inodelog;    /* log2 of sb_inodesize */
-        __uint8_t       sb_inopblog;    /* log2 of sb_inopblock */
-        __uint8_t       sb_agblklog;    /* log2 of sb_agblocks (rounded up) */
-        __uint8_t       sb_rextslog;    /* log2 of sb_rextents */
-        __uint8_t       sb_inprogress;  /* mkfs is in progress, don't mount */
-        __uint8_t       sb_imax_pct;    /* max % of fs for inode space */
+        uint8_t       sb_blocklog;    /* log2 of sb_blocksize */
+        uint8_t       sb_sectlog;     /* log2 of sb_sectsize */
+        uint8_t       sb_inodelog;    /* log2 of sb_inodesize */
+        uint8_t       sb_inopblog;    /* log2 of sb_inopblock */
+        uint8_t       sb_agblklog;    /* log2 of sb_agblocks (rounded up) */
+        uint8_t       sb_rextslog;    /* log2 of sb_rextents */
+        uint8_t       sb_inprogress;  /* mkfs is in progress, don't mount */
+        uint8_t       sb_imax_pct;    /* max % of fs for inode space */
                                         /* statistics */
         /*
          * These fields must remain contiguous.  If you really
          * want to change their layout, make sure you fix the
          * code in xfs_trans_apply_sb_deltas().
          */
-        __uint64_t      sb_icount;      /* allocated inodes */
-        __uint64_t      sb_ifree;       /* free inodes */
-        __uint64_t      sb_fdblocks;    /* free data blocks */
-        __uint64_t      sb_frextents;   /* free realtime extents */
+        uint64_t      sb_icount;      /* allocated inodes */
+        uint64_t      sb_ifree;       /* free inodes */
+        uint64_t      sb_fdblocks;    /* free data blocks */
+        uint64_t      sb_frextents;   /* free realtime extents */
         /*
          * End contiguous fields.
          */
         xfs_ino_t       sb_uquotino;    /* user quota inode */
         xfs_ino_t       sb_gquotino;    /* group quota inode */
-        __uint16_t      sb_qflags;      /* quota flags */
-        __uint8_t       sb_flags;       /* misc. flags */
-        __uint8_t       sb_shared_vn;   /* shared version number */
+        uint16_t      sb_qflags;      /* quota flags */
+        uint8_t       sb_flags;       /* misc. flags */
+        uint8_t       sb_shared_vn;   /* shared version number */
         xfs_extlen_t    sb_inoalignmt;  /* inode chunk alignment, fsblocks */
-        __uint32_t      sb_unit;        /* stripe or raid unit */
-        __uint32_t      sb_width;       /* stripe or raid width */
-        __uint8_t       sb_dirblklog;   /* log2 of dir block size (fsbs) */
-        __uint8_t       sb_logsectlog;  /* log2 of the log sector size */
-        __uint16_t      sb_logsectsize; /* sector size for the log, bytes */
-        __uint32_t      sb_logsunit;    /* stripe unit size for the log */
-        __uint32_t      sb_features2;   /* additional feature bits */
+        uint32_t      sb_unit;        /* stripe or raid unit */
+        uint32_t      sb_width;       /* stripe or raid width */
+        uint8_t       sb_dirblklog;   /* log2 of dir block size (fsbs) */
+        uint8_t       sb_logsectlog;  /* log2 of the log sector size */
+        uint16_t      sb_logsectsize; /* sector size for the log, bytes */
+        uint32_t      sb_logsunit;    /* stripe unit size for the log */
+        uint32_t      sb_features2;   /* additional feature bits */
 
         /*
          * bad features2 field as a result of failing to pad the sb structure to
@@ -161,17 +161,17 @@ struct xfs_sb
          * the value in sb_features2 when formatting the incore superblock to
          * the disk buffer.
          */
-        __uint32_t      sb_bad_features2;
+        uint32_t      sb_bad_features2;
 
         /* version 5 superblock fields start here */
 
         /* feature masks */
-        __uint32_t      sb_features_compat;
-        __uint32_t      sb_features_ro_compat;
-        __uint32_t      sb_features_incompat;
-        __uint32_t      sb_features_log_incompat;
+        uint32_t      sb_features_compat;
+        uint32_t      sb_features_ro_compat;
+        uint32_t      sb_features_incompat;
+        uint32_t      sb_features_log_incompat;
 
-        __uint32_t      sb_crc;         /* superblock crc */
+        uint32_t      sb_crc;         /* superblock crc */
         xfs_extlen_t    sb_spino_align; /* sparse inode chunk alignment */
 
         xfs_ino_t       sb_pquotino;    /* project quota inode */

--- a/src/oper_save.c
+++ b/src/oper_save.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <sys/mount.h>
+#include <sys/param.h>
 #include <sys/statvfs.h>
 #include <sys/stat.h>
 #include <attr/xattr.h>
@@ -540,7 +541,7 @@ int createar_item_stdattr(csavear *save, char *root, char *relpath, struct stat6
             }
             if (*objtype==OBJTYPE_REGFILEUNIQUE || *objtype==OBJTYPE_REGFILEMULTI)
             {
-                if (((u64)statbuf->st_blocks) * ((u64)S_BLKSIZE) < ((u64)statbuf->st_size))
+                if (((u64)statbuf->st_blocks) * ((u64)DEV_BSIZE) < ((u64)statbuf->st_size))
                     flags|=FSA_FILEFLAGS_SPARSE;
             }
             break;


### PR DESCRIPTION
Some patches to fix compilation with the musl c library (http://musl-libc.org.)The format_stacktrace function does not seem to be used anywhere. Removing the function would make my third patch unecessary.