### PR TITLE
Add support for XFSv5 reverse mapping btree

### DIFF
--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -173,6 +173,17 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
         strlcatf(mkfsopts, sizeof(mkfsopts), " -m finobt=%d ", (int)optval);
     }
 
+    // Determine if the "rmapbt" mkfs option should be enabled (reverse mapping btree)
+    // - starting with linux-4.8 XFS has added a btree that maps filesystem blocks
+    //   to their owner
+    // - this feature relies on the new v5 on-disk format but it is optional
+    // - this feature will be enabled if the original filesystem was XFSv5 and had it
+    if (xfstoolsver >= PROGVER(4,8,0)) // only use "rmapbt" option when it is supported by mkfs
+    {
+        optval = ((xfsver==XFS_SB_VERSION_5) && (sb_features_ro_compat & XFS_SB_FEAT_RO_COMPAT_RMAPBT));
+        strlcatf(mkfsopts, sizeof(mkfsopts), " -m rmapbt=%d ", (int)optval);
+    }
+
     // Attempt to preserve UUID of the filesystem
     // - the "-m uuid=<UUID>" option in mkfs.xfs was added in mkfs.xfs 4.3.0 and is the best way to set UUIDs
     // - the UUID of XFSv4 can be successfully set using either xfs_admin or mkfs.xfs >= 4.3.0

--- a/src/fs_xfs.h
+++ b/src/fs_xfs.h
@@ -183,13 +183,15 @@ struct xfs_sb
 
 // XFS features used in XFS version 5 only
 #define XFS_SB_FEAT_RO_COMPAT_FINOBT      (1 << 0)  /* free inode btree */
+#define XFS_SB_FEAT_RO_COMPAT_RMAPBT      (1 << 1)  /* reverse map btree */
 #define XFS_SB_FEAT_INCOMPAT_FTYPE        (1 << 0)  /* filetype in dirent */
 #define XFS_SB_FEAT_INCOMPAT_SPINODES     (1 << 1)  /* sparse inode chunks */
 #define XFS_SB_FEAT_INCOMPAT_META_UUID    (1 << 2)  /* metadata UUID */
 
 // features supported by the current fsarchiver version
 #define FSA_XFS_FEATURE_COMPAT_SUPP       (u64)(0)
-#define FSA_XFS_FEATURE_RO_COMPAT_SUPP    (u64)(XFS_SB_FEAT_RO_COMPAT_FINOBT)
+#define FSA_XFS_FEATURE_RO_COMPAT_SUPP    (u64)(XFS_SB_FEAT_RO_COMPAT_FINOBT|\
+                                                XFS_SB_FEAT_RO_COMPAT_RMAPBT)
 #define FSA_XFS_FEATURE_INCOMPAT_SUPP     (u64)(XFS_SB_FEAT_INCOMPAT_FTYPE|\
                                                 XFS_SB_FEAT_INCOMPAT_SPINODES|\
                                                 XFS_SB_FEAT_INCOMPAT_META_UUID)


### PR DESCRIPTION
Kernel 4.8 [1] introduced a reverse mapping btree. From mkfs.xfs 4.8.0 man page:

> The reverse mapping btree maps filesystem blocks to the owner of the filesystem block. Most of the mappings will be to an inode number and an offset, though there will also be mappings to filesystem metadata. This secondary metadata can be used to validate the primary metadata or to pinpoint exactly which data has been lost when a disk error occurs.

It is experimental, relies on the v5 format and is disabled by default in mkfs.xfs.

Tested with mkfs.xfs 4.8.0-rc3.

[1] https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=0cbbc422d56668528f6efd1234fe908010284082