### PR TITLE
Another doc update

### DIFF
--- a/README
+++ b/README
@@ -4,69 +4,65 @@ fsarchiver: Filesystem Archiver for Linux [http://www.fsarchiver.org]
 
 About FSArchiver
 ----------------
-FSArchiver is a system tool that allows you to save the contents of a 
-file-system to a compressed archive file. The file-system can be restored 
-on a partition which has a different size and it can be restored on a 
-different file-system. Unlike tar/dar, FSArchiver also creates the 
-file-system when it extracts the data to partitions. Everything is 
-checksummed in the archive in order to protect the data. If the archive 
-is corrupt, you just lose the current file, not the whole archive. 
-Fsarchiver is released under the GPL-v2 license. You should read the 
-Quick start guide if you are using FSArchiver for the first time.
+FSArchiver is a system tool that allows you to save the contents of a
+filesystem to a compressed archive file. The filesystem contents can be
+restored on a device which has a different size and it can be restored on a
+different filesystem. Unlike tar/dar, FSArchiver also creates the
+filesystem when it extracts the data to devices. Everything is checksummed
+in the archive in order to protect the data. If the archive is corrupt, you
+just lose the current file, not the whole archive. FSArchiver is released
+under the GPLv2 license. You should read the Quick start guide if you are
+using FSArchiver for the first time.
 
 Detailed description
 --------------------
-The purpose of this project is to provide a safe and flexible file-system 
-backup/deployment tool. Other open-source file-systems tools such as 
-partimage already exist. These tools are working at the filesystem blocks 
-level, so it's not possible to restore the backup to a smaller partition, 
-and restoring to a bigger partition forces you to resize the filesystem 
-by hand.
+The purpose of this project is to provide a safe and flexible filesystem
+backup/deployment tool. Other open-source filesystems tools such as
+Partimage already exist. These tools are working at the filesystem block
+level, so it's not possible to restore the backup to a smaller device, and
+restoring to a bigger one forces you to resize the filesystem by hand.
 
-The purpose is to have a very flexible program. FSArchiver can extract an 
-archive to a partition which is smaller that the original one as long as 
-there is enough space to store the data. It can also restore the data on 
-a different file-system, so it can use it when you want to convert your 
-file-system: you can backup an ext3 file-system, and restore it as a 
-reiserfs.
+The purpose is to have a very flexible program. FSArchiver can extract an
+archive to a device which is smaller that the original one as long as there
+is enough space to store the data. It can also restore the data on a
+different filesystem, so you can use it when you want to convert your
+filesystem: you can backup an EXT3 filesystem, and restore it as ReiserFS.
 
-FSArchiver is working at the file level. It can make an archive of most 
-unix file-system (ext3, reiserfs, xfs, ...) that the running kernel can 
-mount with a read-write support. It will preserve all the standard unix 
-file attributes (permissions, timestamps, symbolic-links, hard-links, 
-extended-attributes, ...), as long as the kernel has support for it 
+FSArchiver works at the file level. It can make an archive of most Linux
+filesystems (EXT3, ReiserFS, XFS, ...) that the running kernel can mount
+with read-write support. It will preserve all the standard Unix file
+attributes (permissions, timestamps, symbolic-links, hard-links,
+extended-attributes, ...), as long as the kernel has support for them
 enabled.
 
 Limitations
 -----------
-There are several limitations anyway: it does not support the fat filesystem.
-FSArchiver won't preserve the features which are very specific to a 
-file-system. For instance, if you create a snapshot in a btrfs volume 
-(the new-generation file system for linux), FSArchiver won't know anything 
-about that, and it will just backup the contents seen when you mount the 
-partition.
+There are limitations anyway: FAT filesystem is supported basically for EFI
+System Partition volumes (UEFI systems) and won't work for bootable Windows
+volumes. Also, NTFS support is experimental and shouldn't be used in
+production. FSArchiver won't preserve features which are very specific to a
+filesystem. For instance, if you create a snapshot in a Btrfs volume,
+FSArchiver won't know anything about that, and it will just backup the
+contents seen when you mount the device.
 
-FSArchiver is safe when it makes backups of partitions which are not mounted 
-or mounted read-only. There is an option to force the backup of a read-write 
-mounted volume, but there may be problems with the files that changed during 
-the backup. If you want to backup partition which are in use, the best thing 
-to do is to make an LVM snapshot of the partition using lvcreate -s, which 
-is part of the LVM userland tools. Unfortunately you can only make snapshots 
-of partitions which are LVM Logical Volumes.
-
-You can have more details about the current status of that project which is 
-under active development.
+FSArchiver is safe when it makes backups of devices which are not mounted
+or are mounted read-only. There is an option to force the backup of a
+read-write mounted volume, but there may be problems with the files that
+changed during the backup. If you want to backup a device which are in use,
+the best thing to do is to make an LVM snapshot of it using lvcreate -s,
+which is part of the LVM userland tools. Unfortunately you can only make
+snapshots of devices which are LVM Logical Volumes.
 
 Protection against data loss
 ----------------------------
-FSArchiver is using two levels of checksums to protect your data against 
-corruption. Each block of each file has a 32bit checksum written in the 
-archive. That way we can identify which block of your file is damaged. Once a 
-file has been restored, the md5 checksum of the whole file is compared to the 
-original md5. It's a 128bit checksum, so it's will detect all file corruptions.
-In case one file is damaged, FSArchiver will restore all the other files from 
-your archive, so you won't lose all your data. It's very different from 
-tar.gz where the whole tar is compressed with gzip. In that case, the data 
-which are written after the corruption are lost. FSArchiver-0.2.3 and newer 
-version are able to ignore corrupt contents in an archive file, so all the 
-other files will be restored.
+FSArchiver is using two levels of checksums to protect your data against
+corruption. Each block of each file has a 32-bit checksum written in the
+archive. That way we can identify which block of your file is damaged. Once
+a file has been restored, the MD5 checksum of the whole file is compared to
+the original MD5. It's a 128-bit checksum, so it will detect all file
+corruptions. In case one file is damaged, FSArchiver will restore all the
+other files from your archive, so you won't lose all your data. It's very
+different from tar.gz where the whole tar is compressed with gzip. In that
+case, the data which are written after the corruption are lost.
+FSArchiver-0.2.3 and newer versions are able to ignore corrupt contents in
+an archive file, so all the other files will be restored.

--- a/distrib/rpm/fsarchiver.spec
+++ b/distrib/rpm/fsarchiver.spec
@@ -21,13 +21,13 @@ BuildRequires:	lzo-devel
 BuildRequires:	xz-devel
 
 %description
-FSArchiver is a system tool that allows you to save the contents of a 
-file-system to a compressed archive file. The file-system can be restored 
-on a partition which has a different size and it can be restored on a 
-different file-system. Unlike tar/dar, FSArchiver also creates the 
-file-system when it extracts the data to partitions. Everything is 
-checksummed in the archive in order to protect the data. If the archive 
-is corrupt, you just lose the current file, not the whole archive.
+FSArchiver is a system tool that allows you to save the contents of a
+filesystem to a compressed archive file. The filesystem contents can be
+restored on a device which has a different size and it can be restored on a
+different filesystem. Unlike tar/dar, FSArchiver also creates the
+filesystem when it extracts the data to devices. Everything is checksummed
+in the archive in order to protect the data. If the archive is corrupt, you
+just lose the current file, not the whole archive.
 
 %prep
 %setup -q


### PR DESCRIPTION
@fdupoux , can you release 0.8.1? FSArchiver XFS support is broken right now on RHEL 7.3 because that uncool change they have made to mkfs.xfs (see 124ff92d5c492d25a0198e27ab0b9a697a0de6f2).