### PR TITLE
Replace <attr/xattr.h> with <sys/xattr.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ PKG_CHECK_MODULES([BLKID], [blkid])
 PKG_CHECK_MODULES([UUID], [uuid])
 
 dnl Check for header files installed with a library
-AC_CHECK_HEADER([attr/xattr.h],, [AC_MSG_ERROR([attr/xattr.h not found. you may have to install a package called attr, libattr, libattr-devel])])
+AC_CHECK_HEADER([sys/xattr.h],, [AC_MSG_ERROR([sys/xattr.h not found.])])
 
 dnl Check for standard header files.
 AC_CHECK_HEADERS([malloc.h unistd.h pthread.h])

--- a/src/oper_restore.c
+++ b/src/oper_restore.c
@@ -24,7 +24,8 @@
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <gcrypt.h>

--- a/src/oper_save.c
+++ b/src/oper_save.c
@@ -29,7 +29,8 @@
 #include <sys/param.h>
 #include <sys/statvfs.h>
 #include <sys/stat.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
+#include <errno.h>
 #include <zlib.h>
 #include <assert.h>
 #include <gcrypt.h>
@@ -58,6 +59,10 @@
 #include "crypto.h"
 #include "error.h"
 #include "queue.h"
+
+#ifndef ENOATTR
+#define ENOATTR ENODATA
+#endif
 
 typedef struct s_savear
 {   carchwriter ai;


### PR DESCRIPTION
The former has been long deprecated and removed in attr-2.4.48

See issue #52