### PR TITLE
Extend comment about XFS sparse inodes

### DIFF
--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -231,6 +231,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     // Determine if the "sparse" mkfs option should be enabled (sparse inode allocation)
     // - starting with linux-4.2 XFS can allocate discontinuous inode chunks
     // - this feature relies on the new v5 on-disk format but it is optional
+    // - this feature is enabled by default when using xfsprogs 4.16 or later
     // - this feature will be enabled if the original filesystem was XFSv5 and had it
     // - this feature is supported since mkfs.xfs 4.2.0, but unfortunately
     //   mkfs.xfs 4.5.0 in RHEL 7.3 carries a custom patch removing the option,
@@ -246,7 +247,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }
-    
+
     // ---- use xfs_admin to set the UUID if not already done with mkfs.xfs
     if (xadmopts[0])
     {
@@ -255,8 +256,8 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
             return -1;
         }
     }
-    
-    return 0;    
+
+    return 0;
 }
 
 int xfs_getinfo(cdico *d, char *devname)
@@ -278,13 +279,13 @@ int xfs_getinfo(cdico *d, char *devname)
     {   ret=-1;
         goto xfs_read_sb_return;
     }
-    
+
     res=read(fd, &sb, sizeof(sb));
     if (res!=sizeof(sb))
     {   ret=-1;
         goto xfs_read_sb_close;
     }
-    
+
     // ---- check it's an XFS file system
     if (be32_to_cpu(sb.sb_magicnum) != XFS_SB_MAGIC)
     {   ret=-1;
@@ -311,7 +312,7 @@ int xfs_getinfo(cdico *d, char *devname)
     // ---- label
     msgprintf(MSG_DEBUG1, "xfs_label=[%s]\n", sb.sb_fname);
     dico_add_string(d, 0, FSYSHEADKEY_FSLABEL, (char*)sb.sb_fname);
-    
+
     // ---- uuid
     /*if ((str=e2p_uuid2str(&sb.sb_uuid))!=NULL)
         dico_add_string(d, 0, FSYSHEADKEY_FSUUID, str);*/
@@ -319,7 +320,7 @@ int xfs_getinfo(cdico *d, char *devname)
     uuid_unparse_lower((u8*)&sb.sb_uuid, uuid);
     dico_add_string(d, 0, FSYSHEADKEY_FSUUID, uuid);
     msgprintf(MSG_DEBUG1, "xfs_uuid=[%s]\n", uuid);
-    
+
     // ---- block size
     temp32=be32_to_cpu(sb.sb_blocksize);
     if ((temp32%512!=0) || (temp32<512) || (temp32>65536))
@@ -351,7 +352,7 @@ int xfs_getinfo(cdico *d, char *devname)
 
     // ---- minimum fsarchiver version required to restore
     dico_add_u64(d, 0, FSYSHEADKEY_MINFSAVERSION, FSA_VERSION_BUILD(0, 6, 20, 0));
-    
+
 xfs_read_sb_close:
     close(fd);
 xfs_read_sb_return:
@@ -372,27 +373,27 @@ int xfs_test(char *devname)
 {
     struct xfs_sb sb;
     int fd;
-    
+
     if ((fd=open64(devname, O_RDONLY|O_LARGEFILE))<0)
     {
         msgprintf(MSG_DEBUG1, "open64(%s) failed\n", devname);
         return false;
     }
-    
+
     memset(&sb, 0, sizeof(sb));
     if (read(fd, &sb, sizeof(sb))!=sizeof(sb))
     {   close(fd);
         msgprintf(MSG_DEBUG1, "read failed\n");
         return false;
     }
-    
+
     // ---- check it's an XFS file system
     if (be32_to_cpu(sb.sb_magicnum) != XFS_SB_MAGIC)
     {   close(fd);
         msgprintf(MSG_DEBUG1, "(be32_to_cpu(sb.sb_magicnum)=%.8x) != (XFS_SB_MAGIC=%.8x)\n", be32_to_cpu(sb.sb_magicnum), XFS_SB_MAGIC);
         return false;
     }
-    
+
     close(fd);
     return true;
 }


### PR DESCRIPTION
Version 4.16 enables `-i sparse` by default.