### PR TITLE
Added 'extract' to access individual files in am archive.

### DIFF
--- a/doc/fsarchiver.8
+++ b/doc/fsarchiver.8
@@ -108,6 +108,9 @@ file and its contents.
 .TP
 .B probe
 Show list of filesystems detected on the disks.
+.TP
+.B extract
+Show archive contents or extract files from the archive.
 
 .SH "OPTIONS"
 .PP
@@ -147,6 +150,13 @@ name or an absolute file/dir path. You must use quotes around the pattern
 each time you use wildcards, else it would be interpreted by the shell. The
 wildcards must be interpreted by fsarchiver. See examples below for more
 details about this option.
+.IP "\fB\-i pattern, \-\-include=pattern\fP"
+Include files and directories that match specified pattern. The pattern can
+contain shell wildcards such as * and ? or may be either a simple file/dir
+name or an absolute file/dir path. You must use quotes around the pattern
+each time you use wildcards, else it would be interpreted by the shell. The
+wildcards must be interpreted by fsarchiver. If no include pattern is
+specified all files are included.
 .IP "\fB\-L label, \-\-label=label\fP"
 Set the label of the archive: it is just a comment about its contents. It
 can be used to remember a particular thing about the archive or the state
@@ -220,6 +230,12 @@ fsarchiver savefs -c - /data/myarchive1.fsa /dev/sda1
 fsarchiver restdir /data/linux-sources.fsa /tmp/extract
 .SS show information about an archive and its filesystems:
 fsarchiver archinfo /data/myarchive2.fsa
+.SS show the content of an archives:
+fsarchiver extract /data/myarchive2.fsa id=0
+.SS show the content of a directory in an archive:
+fsarchiver extract /data/myarchive2.fsa id=0 -i '/dir1/dir2/*'
+.SS extract a file from an archive:
+fsarchiver extract /data/myarchive2.fsa id=0,dest=targetdir -i '/dir/file'
 
 .SH WARNING
 .B fsarchiver

--- a/src/common.c
+++ b/src/common.c
@@ -592,6 +592,22 @@ int exclude_check(cstrlist *patlist, char *string)
     return false;
 }
 
+int include_check(cstrlist *patlist, char *string)
+{
+    char pattern[1024];
+    int count;
+    int i;
+    
+    count=strlist_count(patlist);
+    for (i=0; i < count; i++)
+    {
+        strlist_getitem(patlist, i, pattern, sizeof(pattern));
+        if (fnmatch(pattern, string, 0)==0)
+            return true;
+    }
+    return false;
+}
+
 int get_path_to_volume(char *newvolbuf, int bufsize, char *basepath, long curvol)
 {
     char prefix[PATH_MAX];

--- a/src/common.h
+++ b/src/common.h
@@ -49,6 +49,7 @@ int format_stacktrace(char *buffer, int bufsize);
 int stats_show(struct s_stats, int fsid);
 u64 stats_errcount(struct s_stats stats);
 int exclude_check(struct s_strlist *patlist, char *string);
+int include_check(struct s_strlist *patlist, char *string);
 int get_path_to_volume(char *newvolbuf, int bufsize, char *basepath, long curvol);
 s64 get_device_size(char *partition);
 

--- a/src/fsarchiver.h
+++ b/src/fsarchiver.h
@@ -30,7 +30,7 @@
 #endif
 
 // -------------------------------- fsarchiver commands ---------------------------------------------
-enum {OPER_NULL=0, OPER_SAVEFS, OPER_RESTFS, OPER_SAVEDIR, OPER_RESTDIR, OPER_ARCHINFO, OPER_PROBE};
+enum {OPER_NULL=0, OPER_SAVEFS, OPER_RESTFS, OPER_SAVEDIR, OPER_RESTDIR, OPER_ARCHINFO, OPER_PROBE, OPER_EXTRACT};
 
 // ----------------------------------- dico sections ------------------------------------------------
 enum {DICO_OBJ_SECTION_STDATTR=0, DICO_OBJ_SECTION_XATTR=1, DICO_OBJ_SECTION_WINATTR=2};

--- a/src/options.h
+++ b/src/options.h
@@ -42,6 +42,7 @@ struct s_options
 	char     archlabel[FSA_MAX_LABELLEN];
     u8       encryptpass[FSA_MAX_PASSLEN+1];
     cstrlist exclude;
+    cstrlist include;
 };
 
 extern coptions g_options;

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -207,6 +207,7 @@ Distributed under the GPL v2 license (GNU General Public License v2).
  * restdir: restore data from an archive which is not based on a filesystem
  * archinfo: show information about an existing archive file and its contents
  * probe [detailed]: show list of filesystems detected on the disks
+ * extract: Show the content of an archive or extract files from the archive
 <options>
  -o: overwrite the archive if it already exists instead of failing
  -v: verbose mode (can be used several times to increase the level of details)
@@ -215,6 +216,7 @@ Distributed under the GPL v2 license (GNU General Public License v2).
  -a: allow to save a filesystem when acls and xattrs are not supported
  -x: enable support for experimental features (they are disabled by default)
  -e <pattern>: exclude files and directories that match that pattern
+ -i <pattern>: include files and directories that match that pattern
  -L <label>: set the label of the archive (comment about the contents)
  -z <level>: legacy compression level from 0 (very fast) to 9 (very good)
  -Z <level>: zstd compression level from 1 (very fast) to 22 (very good)
@@ -261,4 +263,10 @@ Distributed under the GPL v2 license (GNU General Public License v2).
    fsarchiver restdir /data/linux-sources.fsa /tmp/extract
  * show information about an archive and its filesystems:
    fsarchiver archinfo /data/myarchive2.fsa
+ * show the content of an archives:
+   fsarchiver extract /data/myarchive2.fsa id=0
+ * show the content of a directory in an archive:
+   fsarchiver extract /data/myarchive2.fsa id=0 -i '/dir1/dir2/*'
+ * extract a file from an archive:
+   fsarchiver extract /data/myarchive2.fsa id=0,dest=targetdir -i '/dir/file'
 ```


### PR DESCRIPTION
Hi,

I'm not the first to do so, but I added an 'extract' command to fsachiver. The command can be used to extract individual files or directories from an archive file without restoring the whole archive.

Most of the functionality was added to oper_restore.c because it was the easiest way to avoid code duplication. The 'extract' command needs a target directory and one or more patters to select the files to extract.
The target directory can be specified like the destdir for directory archives and with the 'dest=' option for filesystem archives. When no target directory is specified 'extract' writes the object types, names,  sizes (for regular files) and targets (for links) to stdout (kind of an 'ls' for fsarchiver).
The files to be extracted can be selected with the '-i' (or '--include') option similar to the existing exclude option. The include option is also active when the filesystem or directory  is restored. The default when no include option is given is to include all files.
I tried to update the documentation and examples with explanations of the new functionality.

I would be glad if the extension is useful.

Cheers
        Peter