### PR TITLE
Lower xfsprogs requirement for mkfs.xfs -i sparse

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -27,12 +27,14 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <sys/utsname.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <wordexp.h>
 #include <fnmatch.h>
 #include <time.h>
 #include <limits.h>
+#include <regex.h>
 
 #ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
@@ -629,4 +631,24 @@ s64 get_device_size(char *partition)
     close(fd);
 
     return devsize;
+}
+
+bool match_uname_r(char *ere)
+{
+    int r;
+    struct utsname ut;
+    regex_t reg;
+
+    if (uname(&ut) != 0)
+        return false;
+
+    // do not bother with invalid regex, since it is not user configurable
+    if (regcomp(&reg, ere, REG_EXTENDED|REG_NOSUB) != 0)
+        return false;
+
+    r = !regexec(&reg, ut.release, 0, NULL, 0);
+
+    msgprintf(MSG_VERB2, "match_uname_r(%s)=[%s], kernel=[%s]\n", ere, r ? "true" : "false", ut.release);
+
+    return r;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -51,5 +51,6 @@ u64 stats_errcount(struct s_stats stats);
 int exclude_check(struct s_strlist *patlist, char *string);
 int get_path_to_volume(char *newvolbuf, int bufsize, char *basepath, long curvol);
 s64 get_device_size(char *partition);
+bool match_uname_r(char *ere);
 
 #endif // __COMMON_H__

--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -34,6 +34,9 @@
 #include "strlist.h"
 #include "error.h"
 
+// POSIX Extended Regular Expression to match RHEL 7 kernel releases
+#define RHEL7_KERNEL_ERE "[[:digit:]]+\\.el7(uek)?\\."
+
 int xfs_check_compatibility(u64 compat, u64 ro_compat, u64 incompat, u64 log_incompat)
 {
     int errors=0;
@@ -230,10 +233,10 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     // - this feature relies on the V5 on-disk format but it is optional
     // - this feature is enabled by default when using xfsprogs-4.16.0 or later
     // - this feature will be enabled if the original filesystem was XFS V5 and had it
-    // - this feature is supported since mkfs.xfs 4.2.0, but unfortunately mkfs.xfs 4.5.0
-    //   in RHEL 7.3 carries a custom patch removing the option, hence require mkfs.xfs
-    //   4.7.0, next version after 4.5.0
-    if (xfstoolsver >= PROGVER(4,7,0)) // only use "sparse" option when it is supported by mkfs
+    // - this feature is supported since mkfs.xfs 4.2.0
+    // - mkfs.xfs 4.5.0 in RHEL 7.3 carries a custom patch removing the option
+    if (xfstoolsver >= PROGVER(4,2,0) &&
+        !match_uname_r(RHEL7_KERNEL_ERE)) // only use "sparse" option when it is supported by mkfs
     {
         optval = ((xfsver==XFS_SB_VERSION_5) && (sb_features_incompat & XFS_SB_FEAT_INCOMPAT_SPINODES));
         strlcatf(mkfsopts, sizeof(mkfsopts), " -i sparse=%d ", (int)optval);


### PR DESCRIPTION
Current code does not allow -i sparse with mkfs.xfs 4.2.0, 4.3.0 and 4.5.0, despite these
versions supporting the feature just fine, because RHEL 7 craziness.

Add match_uname_r() util function to match ERE against kernel release version and exclude
-i sparse only when running in RHEL 7. The ERE "[[:digit:]]+\\.el7(uek)?\\." shall match all
variants (and hopefully nothing else):

3.10.0-1127.el7.x86_64
3.10.0-1062.18.1.el7.x86_64             (RHEL/CentOS)
3.10.0-1062.1.1.el7.centos.plus.x86_64  (CentOS Plus)
4.4.220-1.el7.elrepo.x86_64             (ELRepo)
4.14.35-1902.11.3.1.el7uek.x86_64       (Oracle Linux UEK)

***
This PR is courtesy of COVID-19 quarantaine monotony. :-)