### PR TITLE
Add mkfsopt command line options latter in mkfs invocation

### DIFF
--- a/src/fs_btrfs.c
+++ b/src/fs_btrfs.c
@@ -87,8 +87,6 @@ int btrfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char
     // ---- set the advanced filesystem settings from the dico
     memset(options, 0, sizeof(options));
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(options, sizeof(options), " -L '%s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
@@ -101,7 +99,10 @@ int btrfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char
 
     if (dico_get_u64(d, 0, FSYSHEADKEY_FSBTRFSSECTORSIZE, &temp64)==0)
         strlcatf(options, sizeof(options), " -s %ld ", (long)temp64);
-    
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
+
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.btrfs -f %s %s", partition, options)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;

--- a/src/fs_ext2.c
+++ b/src/fs_ext2.c
@@ -210,8 +210,6 @@ int extfs_mkfs(cdico *d, char *partition, int extfstype, char *fsoptions, char *
     // "mke2fs -F" removes confirmation prompt when device is a whole disk such as /dev/sda
     strlcatf(options, sizeof(options), " -F ");
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     strlcatf(options, sizeof(options), " -b %ld ", (long)devblksize);
 
     // ---- set the advanced filesystem settings from the dico
@@ -374,6 +372,9 @@ int extfs_mkfs(cdico *d, char *partition, int extfstype, char *fsoptions, char *
         strlcatf(options, sizeof(options), " -E stride=%ld ", (long)temp64);
     if ((dico_get_u64(d, 0, FSYSHEADKEY_FSEXTEOPTRAIDSTRIPEWIDTH, &temp64)==0) && e2fstoolsver>=PROGVER(1,40,7))
         strlcatf(options, sizeof(options), " -E stripe-width=%ld ", (long)temp64);
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
 
     // ---- execute mke2fs
     msgprintf(MSG_VERB2, "exec: %s\n", command);

--- a/src/fs_jfs.c
+++ b/src/fs_jfs.c
@@ -52,12 +52,13 @@ int jfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     // ---- set the advanced filesystem settings from the dico
     memset(options, 0, sizeof(options));
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(options, sizeof(options), " -L '%s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
         strlcatf(options, sizeof(options), " -L '%s' ", buffer);
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
 
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "jfs_mkfs -q %s %s", options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);

--- a/src/fs_ntfs.c
+++ b/src/fs_ntfs.c
@@ -53,8 +53,6 @@ int ntfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char 
     // ---- set the advanced filesystem settings from the dico
     memset(options, 0, sizeof(options));
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(options, sizeof(options), " --label '%s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
@@ -65,7 +63,10 @@ int ntfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char 
     
     if (dico_get_u32(d, 0, FSYSHEADKEY_NTFSCLUSTERSIZE, &temp32)==0)
         strlcatf(options, sizeof(options), " -c %ld ", (long)temp32);
-    
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
+
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.ntfs -f %s %s", partition, options)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;

--- a/src/fs_reiser4.c
+++ b/src/fs_reiser4.c
@@ -53,8 +53,6 @@ int reiser4_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, ch
     // ---- set the advanced filesystem settings from the dico
     memset(options, 0, sizeof(options));
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(options, sizeof(options), " -L '%.16s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
@@ -67,7 +65,10 @@ int reiser4_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, ch
         strlcatf(options, sizeof(options), " -U %s ", mkfsuuid);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSUUID, buffer, sizeof(buffer))==0 && strlen(buffer)==36)
         strlcatf(options, sizeof(options), " -U %s ", buffer);
-    
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
+
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.reiser4 -y %s %s", partition, options)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;

--- a/src/fs_reiserfs.c
+++ b/src/fs_reiserfs.c
@@ -52,8 +52,6 @@ int reiserfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, c
     // ---- set the advanced filesystem settings from the dico
     memset(options, 0, sizeof(options));
 
-    strlcatf(options, sizeof(options), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(options, sizeof(options), " -l '%.16s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
@@ -66,7 +64,10 @@ int reiserfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, c
         strlcatf(options, sizeof(options), " -u %s ", mkfsuuid);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSUUID, buffer, sizeof(buffer))==0 && strlen(buffer)==36)
         strlcatf(options, sizeof(options), " -u %s ", buffer);
-    
+
+    // ---- mkfsopt from command line
+    strlcatf(options, sizeof(options), " %s ", fsoptions);
+
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkreiserfs -f %s %s", partition, options)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;

--- a/src/fs_vfat.c
+++ b/src/fs_vfat.c
@@ -68,6 +68,9 @@ int vfat_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char 
     if (dico_get_u32(d, 0, FSYSHEADKEY_FSVFATSERIAL, &temp32)==0)
         strlcatf(mkfsopts, sizeof(mkfsopts), " -i '%08X' ", temp32);
 
+    // ---- mkfsopt from command line
+    strlcatf(mkfsopts, sizeof(mkfsopts), " %s ", fsoptions);
+
     // ---- create the new filesystem using mkfs.vfat
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.vfat %s %s", mkfsopts, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);

--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -106,8 +106,6 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     memset(xadmopts, 0, sizeof(xadmopts));
     memset(uuid, 0, sizeof(uuid));
 
-    strlcatf(mkfsopts, sizeof(mkfsopts), " %s ", fsoptions);
-
     if (strlen(mkfslabel) > 0)
         strlcatf(mkfsopts, sizeof(mkfsopts), " -L '%.12s' ", mkfslabel);
     else if (dico_get_string(d, 0, FSYSHEADKEY_FSLABEL, buffer, sizeof(buffer))==0 && strlen(buffer)>0)
@@ -241,6 +239,9 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
         optval = ((xfsver==XFS_SB_VERSION_5) && (sb_features_incompat & XFS_SB_FEAT_INCOMPAT_SPINODES));
         strlcatf(mkfsopts, sizeof(mkfsopts), " -i sparse=%d ", (int)optval);
     }
+
+    // ---- mkfsopt from command line
+    strlcatf(mkfsopts, sizeof(mkfsopts), " %s ", fsoptions);
 
     // ---- create the new filesystem using mkfs.xfs
     if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.xfs -f %s %s", partition, mkfsopts)!=0 || exitst!=0)


### PR DESCRIPTION
When the same option is specified multiple times, generally the last one wins.
Users will have more chance in overriding mkfs settings.

Also implement it in src/fs_vfat.c.

***

Prompted by #84