### PR TITLE
Fix fallback compression attempt with zstd enabled

### DIFF
--- a/src/fsarchiver.c
+++ b/src/fsarchiver.c
@@ -196,14 +196,12 @@ int process_cmdline(int argc, char **argv)
     g_options.encryptpass[0]=0;
 
     // set default compression mode
-#ifdef OPTION_ZSTD_SUPPORT
-    g_options.fsacomplevel=FSA_DEF_ZSTD_LEVEL;
-    g_options.compressalgo=COMPRESS_ZSTD;
-    g_options.compresslevel=FSA_DEF_ZSTD_LEVEL;
-#else
-    g_options.fsacomplevel=3; // fsa level 3 = "gzip -6"
     g_options.compressalgo=FSA_DEF_COMPRESS_ALGO;
-    g_options.compresslevel=FSA_DEF_COMPRESS_LEVEL; // default level for gzip
+    g_options.compresslevel=FSA_DEF_COMPRESS_LEVEL;
+#ifdef OPTION_ZSTD_SUPPORT
+    g_options.fsacomplevel=FSA_DEF_COMPRESS_LEVEL;
+#else
+    g_options.fsacomplevel=FSA_DEF_FSACOMP_LEVEL;
 #endif // OPTION_ZSTD_SUPPORT
 
     while ((c = getopt_long(argc, argv, "oaAvdj:hVs:c:L:e:xz:Z:", long_options, NULL)) != EOF)

--- a/src/fsarchiver.h
+++ b/src/fsarchiver.h
@@ -124,9 +124,14 @@ enum {OLDERR_FATAL=1,
 #define FSA_MAX_QUEUESIZE        32
 #define FSA_MAX_BLKSIZE          921600
 #define FSA_DEF_BLKSIZE          524288
-#define FSA_DEF_COMPRESS_ALGO    COMPRESS_GZIP  // legacy compression is using gzip by default
-#define FSA_DEF_COMPRESS_LEVEL   6              // legacy compression is with "gzip -6" by default
-#define FSA_DEF_ZSTD_LEVEL       8              // default compression level when zstd is used
+#ifdef OPTION_ZSTD_SUPPORT
+ #define FSA_DEF_COMPRESS_ALGO   COMPRESS_ZSTD
+ #define FSA_DEF_COMPRESS_LEVEL  8
+#else
+ #define FSA_DEF_COMPRESS_ALGO   COMPRESS_GZIP
+ #define FSA_DEF_COMPRESS_LEVEL  6
+#endif
+#define FSA_DEF_FSACOMP_LEVEL    3              // legacy -z mapping for gzip level 6
 #define FSA_MAX_SMALLFILECOUNT   512            // there can be up to FSA_MAX_SMALLFILECOUNT files copied in a single data block
 #define FSA_MAX_SMALLFILESIZE    131072         // files smaller than that will be grouped with other small files in a single data block
 #define FSA_COST_PER_FILE        16384          // how much it cost to copy an empty file/dir/link: used to eval the progress bar


### PR DESCRIPTION
When zstd compression fails because ENOMEM, the code would fallback to gzip instead of lower zstd levels.