### PR TITLE
Specify device as the last argument in mkfs calls

### DIFF
--- a/src/fs_btrfs.c
+++ b/src/fs_btrfs.c
@@ -103,7 +103,7 @@ int btrfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char
     // ---- mkfsopt from command line
     strlcatf(options, sizeof(options), " %s ", fsoptions);
 
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.btrfs -f %s %s", partition, options)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.btrfs -f %s %s", options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }

--- a/src/fs_ext2.c
+++ b/src/fs_ext2.c
@@ -378,7 +378,7 @@ int extfs_mkfs(cdico *d, char *partition, int extfstype, char *fsoptions, char *
 
     // ---- execute mke2fs
     msgprintf(MSG_VERB2, "exec: %s\n", command);
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "%s %s %s", progname, partition, options)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "%s %s %s", progname, options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed with return status=%d\n", command, exitst);
         ret=-1;
         goto extfs_mkfs_cleanup;
@@ -401,7 +401,7 @@ int extfs_mkfs(cdico *d, char *partition, int extfstype, char *fsoptions, char *
 
     if (options[0])
     {
-        if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "tune2fs %s %s", partition, options)!=0 || exitst!=0)
+        if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "tune2fs %s %s", options, partition)!=0 || exitst!=0)
         {   errprintf("command [%s] failed with return status=%d\n", command, exitst);
             ret=-1;
             goto extfs_mkfs_cleanup;

--- a/src/fs_jfs.c
+++ b/src/fs_jfs.c
@@ -74,7 +74,7 @@ int jfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
 
     if (options[0])
     {
-        if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "jfs_tune %s %s", partition, options)!=0 || exitst!=0)
+        if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "jfs_tune %s %s", options, partition)!=0 || exitst!=0)
         {   errprintf("command [%s] failed\n", command);
             return -1;
         }

--- a/src/fs_ntfs.c
+++ b/src/fs_ntfs.c
@@ -67,7 +67,7 @@ int ntfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char 
     // ---- mkfsopt from command line
     strlcatf(options, sizeof(options), " %s ", fsoptions);
 
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.ntfs -f %s %s", partition, options)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.ntfs -f %s %s", options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }

--- a/src/fs_reiser4.c
+++ b/src/fs_reiser4.c
@@ -69,7 +69,7 @@ int reiser4_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, ch
     // ---- mkfsopt from command line
     strlcatf(options, sizeof(options), " %s ", fsoptions);
 
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.reiser4 -y %s %s", partition, options)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.reiser4 -y %s %s", options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }

--- a/src/fs_reiserfs.c
+++ b/src/fs_reiserfs.c
@@ -68,7 +68,7 @@ int reiserfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, c
     // ---- mkfsopt from command line
     strlcatf(options, sizeof(options), " %s ", fsoptions);
 
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkreiserfs -f %s %s", partition, options)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkreiserfs -f %s %s", options, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }

--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -244,7 +244,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     strlcatf(mkfsopts, sizeof(mkfsopts), " %s ", fsoptions);
 
     // ---- create the new filesystem using mkfs.xfs
-    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.xfs -f %s %s", partition, mkfsopts)!=0 || exitst!=0)
+    if (exec_command(command, sizeof(command), &exitst, NULL, 0, NULL, 0, "mkfs.xfs -f %s %s", mkfsopts, partition)!=0 || exitst!=0)
     {   errprintf("command [%s] failed\n", command);
         return -1;
     }


### PR DESCRIPTION
As recommended by all man pages.

Attempt to fix #91