### PR TITLE
Implement uuid= for vfat

### DIFF
--- a/src/fs_vfat.c
+++ b/src/fs_vfat.c
@@ -65,7 +65,9 @@ int vfat_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char 
         strlcatf(mkfsopts, sizeof(mkfsopts), " -n '%.11s' ", buffer);
 
     // ---- filesystem serial
-    if (dico_get_u32(d, 0, FSYSHEADKEY_FSVFATSERIAL, &temp32)==0)
+    if (strlen(mkfsuuid) > 0)
+        strlcatf(mkfsopts, sizeof(mkfsopts), " -i '%.8s' ", mkfsuuid);
+    else if (dico_get_u32(d, 0, FSYSHEADKEY_FSVFATSERIAL, &temp32)==0)
         strlcatf(mkfsopts, sizeof(mkfsopts), " -i '%08X' ", temp32);
 
     // ---- mkfsopt from command line


### PR DESCRIPTION
Although vfat does not use UUID, we can abuse the option to pass as a string
the u32 number (as hex, without "0x" prefix) to it.