### PR TITLE
Update Btrfs supported features

### DIFF
--- a/src/fs_btrfs.h
+++ b/src/fs_btrfs.h
@@ -29,33 +29,48 @@ int btrfs_check_support_for_features(u64 compat, u64 incompat, u64 ro_compat);
 int btrfs_get_reqmntopt(char *partition, struct s_strlist *reqopt, struct s_strlist *badopt);
 int btrfs_test(char *devname);
 
-// compat flags: official definition from linux-3.14/fs/btrfs/ctree.h
+// compat flags: official definition from linux-5.15/fs/btrfs/ctree.h
+// and linux-5.15/include/uapi/linux/btrfs.h
+#define BTRFS_FEATURE_COMPAT_RO_FREE_SPACE_TREE        (1ULL << 0)
+#define BTRFS_FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID  (1ULL << 1)
+#define BTRFS_FEATURE_COMPAT_RO_VERITY                 (1ULL << 2)
+
 #define BTRFS_FEATURE_INCOMPAT_MIXED_BACKREF    (1ULL << 0)
 #define BTRFS_FEATURE_INCOMPAT_DEFAULT_SUBVOL   (1ULL << 1)
 #define BTRFS_FEATURE_INCOMPAT_MIXED_GROUPS     (1ULL << 2)
 #define BTRFS_FEATURE_INCOMPAT_COMPRESS_LZO     (1ULL << 3)
-#define BTRFS_FEATURE_INCOMPAT_COMPRESS_LZOv2   (1ULL << 4)
+#define BTRFS_FEATURE_INCOMPAT_COMPRESS_ZSTD    (1ULL << 4)
 #define BTRFS_FEATURE_INCOMPAT_BIG_METADATA     (1ULL << 5)
 #define BTRFS_FEATURE_INCOMPAT_EXTENDED_IREF    (1ULL << 6)
 #define BTRFS_FEATURE_INCOMPAT_RAID56           (1ULL << 7)
 #define BTRFS_FEATURE_INCOMPAT_SKINNY_METADATA  (1ULL << 8)
 #define BTRFS_FEATURE_INCOMPAT_NO_HOLES         (1ULL << 9)
+#define BTRFS_FEATURE_INCOMPAT_METADATA_UUID    (1ULL << 10)
+#define BTRFS_FEATURE_INCOMPAT_RAID1C34         (1ULL << 11)
+#define BTRFS_FEATURE_INCOMPAT_ZONED            (1ULL << 12)
 
 // compat flags: btrfs features that this fsarchiver version supports
 #define FSA_BTRFS_FEATURE_COMPAT_SUPP           0ULL
-#define FSA_BTRFS_FEATURE_COMPAT_RO_SUPP        0ULL
+
+#define FSA_BTRFS_FEATURE_COMPAT_RO_SUPP                 \
+        (BTRFS_FEATURE_COMPAT_RO_FREE_SPACE_TREE |       \
+         BTRFS_FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID | \
+         BTRFS_FEATURE_COMPAT_RO_VERITY)
+
 #define FSA_BTRFS_FEATURE_INCOMPAT_SUPP                 \
         (BTRFS_FEATURE_INCOMPAT_MIXED_BACKREF |         \
          BTRFS_FEATURE_INCOMPAT_DEFAULT_SUBVOL |        \
          BTRFS_FEATURE_INCOMPAT_MIXED_GROUPS |          \
          BTRFS_FEATURE_INCOMPAT_BIG_METADATA |          \
          BTRFS_FEATURE_INCOMPAT_COMPRESS_LZO |          \
-         BTRFS_FEATURE_INCOMPAT_COMPRESS_LZOv2 |        \
+         BTRFS_FEATURE_INCOMPAT_COMPRESS_ZSTD |         \
          BTRFS_FEATURE_INCOMPAT_RAID56 |                \
          BTRFS_FEATURE_INCOMPAT_EXTENDED_IREF |         \
          BTRFS_FEATURE_INCOMPAT_SKINNY_METADATA |       \
-         BTRFS_FEATURE_INCOMPAT_NO_HOLES)
-
+         BTRFS_FEATURE_INCOMPAT_NO_HOLES |              \
+         BTRFS_FEATURE_INCOMPAT_METADATA_UUID |         \
+         BTRFS_FEATURE_INCOMPAT_RAID1C34 |              \
+         BTRFS_FEATURE_INCOMPAT_ZONED)
 
 // disk layout definitions
 #define BTRFS_SUPER_MAGIC 0x9123683E


### PR DESCRIPTION
mkfs.btrfs 5.15 has changed defaults:

https://github.com/kdave/btrfs-progs/blob/v5.15/CHANGES

Add a bunch of defines for the new features.

Fixes #113