### PR TITLE
Add XFS nrext64 feature

### DIFF
--- a/src/fs_xfs.c
+++ b/src/fs_xfs.c
@@ -170,8 +170,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     }
 
     // Determine if the "rmapbt" mkfs option should be enabled (reverse mapping btree)
-    // - starting with linux-4.8 XFS has added a btree that maps filesystem blocks to
-    //   their owner
+    // - starting with linux-4.8 XFS has added a btree that maps filesystem blocks to their owner
     // - this feature relies on the V5 on-disk format but it is optional
     // - this feature will be enabled if the original filesystem was XFS V5 and had it
     if (xfstoolsver >= PROGVER(4,8,0)) // only use "rmapbt" option when it is supported by mkfs
@@ -196,6 +195,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     //   to reduce mount times
     // - this optional feature relies on the V5 on-disk format and on the "finobt"
     //   (free inode btree) mkfs option being enabled
+    // - this feature is enabled by default when using xfsprogs-5.15.0 or later
     // - this feature will be enabled if the original filesystem was XFS V5 and had it
     if (xfstoolsver >= PROGVER(5,10,0)) // only use "inobtcount" option when it is supported by mkfs
     {
@@ -206,6 +206,7 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     // Determine if the "bigtime" mkfs option should be enabled (large timestamps)
     // - starting with linux-5.10 XFS has added support for larger inode timestamps, beyond january 2038
     // - this feature relies on the V5 on-disk format but it is optional
+    // - this feature is enabled by default when using xfsprogs-5.15.0 or later
     // - this feature will be enabled if the original filesystem was XFS V5 and had it
     if (xfstoolsver >= PROGVER(5,10,0)) // only use "bigtime" option when it is supported by mkfs
     {
@@ -260,6 +261,16 @@ int xfs_mkfs(cdico *d, char *partition, char *fsoptions, char *mkfslabel, char *
     {
         optval = ((xfsver==XFS_SB_VERSION_5) && (sb_features_incompat & XFS_SB_FEAT_INCOMPAT_SPINODES));
         strlcatf(mkfsopts, sizeof(mkfsopts), " -i sparse=%d ", (int)optval);
+    }
+
+    // Determine if the "nrext64" mkfs option should be enabled (large extent counters)
+    // - starting with linux-5.19 XFS has added support for larger number of per-file extents
+    // - this feature relies on the V5 on-disk format but it is optional
+    // - this feature will be enabled if the original filesystem was XFS V5 and had it
+    if (xfstoolsver >= PROGVER(5,19,0)) // only use "nrext64" option when it is supported by mkfs
+    {
+        optval = ((xfsver==XFS_SB_VERSION_5) && (sb_features_incompat & XFS_SB_FEAT_INCOMPAT_NREXT64));
+        strlcatf(mkfsopts, sizeof(mkfsopts), " -i nrext64=%d ", (int)optval);
     }
 
     // ---- mkfsopt from command line

--- a/src/fs_xfs.h
+++ b/src/fs_xfs.h
@@ -190,6 +190,8 @@ struct xfs_sb
 #define XFS_SB_FEAT_INCOMPAT_SPINODES     (1 << 1)  /* sparse inode chunks */
 #define XFS_SB_FEAT_INCOMPAT_META_UUID    (1 << 2)  /* metadata UUID */
 #define XFS_SB_FEAT_INCOMPAT_BIGTIME      (1 << 3)  /* large timestamps */
+#define XFS_SB_FEAT_INCOMPAT_NEEDSREPAIR  (1 << 4)  /* needs xfs_repair */
+#define XFS_SB_FEAT_INCOMPAT_NREXT64      (1 << 5)  /* large extent counters */
 
 // features supported by the current fsarchiver version
 #define FSA_XFS_FEATURE_COMPAT_SUPP       (u64)(0)
@@ -200,7 +202,9 @@ struct xfs_sb
 #define FSA_XFS_FEATURE_INCOMPAT_SUPP     (u64)(XFS_SB_FEAT_INCOMPAT_FTYPE|\
                                                 XFS_SB_FEAT_INCOMPAT_SPINODES|\
                                                 XFS_SB_FEAT_INCOMPAT_META_UUID|\
-                                                XFS_SB_FEAT_INCOMPAT_BIGTIME)
+                                                XFS_SB_FEAT_INCOMPAT_BIGTIME|\
+                                                XFS_SB_FEAT_INCOMPAT_NEEDSREPAIR|\
+                                                XFS_SB_FEAT_INCOMPAT_NREXT64)
 #define FSA_XFS_FEATURE_LOG_INCOMPAT_SUPP (u64)(0)
 
 #endif // __FS_XFS_H__


### PR DESCRIPTION
Available since kernel/xfsprogs 5.19.0.

Both not released yet, but the code is already there. Tested with kernel 5.19-rc8 and xfsprogs 5.19.0-rc0.1.